### PR TITLE
Replace not allowed character , and add allowed .

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -20,7 +20,7 @@ func isalphanumeric(b byte) bool {
 
 // Clean up AMI name by replacing invalid characters with "-"
 func templateCleanAMIName(s string) string {
-	allowed := []byte{'(', ')', ',', '/', '-', '_', ' '}
+	allowed := []byte{'(', ')', '.', '/', '-', '_', ' '}
 	b := []byte(s)
 	newb := make([]byte, len(b))
 	for i, c := range b {


### PR DESCRIPTION
Fixes error:

```
Error creating AMI: InvalidAMIName.Malformed: AMI names must be between 3 and 128 characters long, and may contain letters, numbers, '(', ')', '.', '-', '/' and '_'
    status code: 400, request id: []
```
